### PR TITLE
Update errorformat to capture continuation lines

### DIFF
--- a/src/main/resources/vim-sbt/plugin/sbtquickfix.vim
+++ b/src/main/resources/vim-sbt/plugin/sbtquickfix.vim
@@ -1,6 +1,6 @@
-set errorformat=%E\ %#[error]\ %#%f:%l:\ %m,%-Z\ %#[error]\ %p^,%-C\ %#[error]\ %m
-set errorformat+=,%W\ %#[warn]\ %#%f:%l:\ %m,%-Z\ %#[warn]\ %p^,%-C\ %#[warn]\ %m
-set errorformat+=,%-G%.%#
+set errorformat=%E\ %#[error]\ %#%f:%l:\ %m,%-Z\ %#[error]\ %p^,%-G\ %#[error]\ %m
+set errorformat+=%W\ %#[warn]\ %#%f:%l:\ %m,%-Z\ %#[warn]\ %p^,%-G\ %#[warn]\ %m
+set errorformat+=%C\ %#%m
 
 let s:relativeQFLocation = "target/quickfix/sbt.quickfix"
 


### PR DESCRIPTION
Lines following errors that don't start with [error] are part of the original error message so should be included.  The primary example are type mismatches, which previously only reported "type mismatch;".  Addresses issue #3.
