### PR TITLE
Auto-truncate quickfix file on clean build

### DIFF
--- a/src/main/scala/com/dscleaver/sbt/quickfix/QuickFixLogger.scala
+++ b/src/main/scala/com/dscleaver/sbt/quickfix/QuickFixLogger.scala
@@ -3,10 +3,10 @@ package com.dscleaver.sbt.quickfix
 import sbt._
 
 object QuickFixLogger {
-  def append(output: File, prefix: String, message: String): Unit = 
+  def append(output: File, prefix: String, message: String): Unit =
     IO.append(output, "[%s] %s\n".format(prefix, message))
 
-  def append(output: File, prefix: String, file: File, line: Int, message: String): Unit = 
+  def append(output: File, prefix: String, file: File, line: Int, message: String): Unit =
     append(output, prefix, "%s:%d: %s".format(file, line, message))
 }
 
@@ -21,17 +21,18 @@ class QuickFixLogger(val output: File, vimExec: String, enableServer: Boolean) e
     case _ => handleDebugMessage(message)
   }
 
-  def handleDebugMessage(message: String) =
+  def handleDebugMessage(message: String) = {
+    if (message.toLowerCase.contains("initial source changes:")) {
+      IO.delete(output)
+      IO.touch(List(output))
+    }
+
     if (enableServer && message.toLowerCase.contains("compilation failed")) {
       call(vimExec, "<esc>:cfile %s<cr>".format(output.toString))
     }
-
-  def handleInfoMessage(message: String) = {
-    if(message startsWith "Compiling") {
-      IO.delete(output)
-      IO.touch(List(output))
-    } else ()
   }
+
+  def handleInfoMessage(message: String) = ()
 
   def handleErrorMessage(message: String) = append(output, "error", message)
 


### PR DESCRIPTION
With reference to: https://github.com/dscleaver/sbt-quickfix/issues/10

I understood why the quickfix doesn't get truncated sometimes: it has to do with the fact that clean builds are cached and fixing issues can get you in a run where the "Compiling" message is not thrown in the logs. Using the debug logs I could find an invariant message that I could then use to reset the quickfix before running compilation in any case.

Please let me know if you find this useful!
