### PR TITLE
Ignore Vim tags file generate for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.sw[op]
 target/
+tags


### PR DESCRIPTION
I'm using the Vim plugin with Pathogen cloning this repo directly in my vim config added as a Git submodule. Because Vim creates src/main/resources/vim-sbt/doc/tags to index the doc file, I'd like to ignore this file so that repo is in a clean status all the time.
