### PR TITLE
Fix compatibility with SBT 0.13.8

### DIFF
--- a/src/main/scala/com/dscleaver/sbt/SbtQuickFix.scala
+++ b/src/main/scala/com/dscleaver/sbt/SbtQuickFix.scala
@@ -25,10 +25,12 @@ object SbtQuickFix extends Plugin {
       (key: ScopedKey[_]) => {
         val loggers = currentFunction(key)
         val taskOption = key.scope.task.toOption
-        if (taskOption.map(_.label) == Some("compile"))
-          new QuickFixLogger(target / "sbt.quickfix", vimExec, enableServer) +: loggers
-        else
-          loggers
+        taskOption.map(_.label) match {
+          case Some(task) if task.toLowerCase.contains("compile") =>
+            new QuickFixLogger(target / "sbt.quickfix", vimExec, enableServer) +: loggers
+          case _ =>
+            loggers
+        }
       }
     },
     testListeners <+= (quickFixDirectory, sources in Test, vimExecutable, vimEnableServer) map { (target, testSources, vimExec, enableServer) =>


### PR DESCRIPTION
The issue was due to sbt changing the task name from "compile" to "compileIncremental". The fix was
to check for the string "compile" in the task name where previously it only matched on exactly
"compile".