### PR TITLE
Log compile:compileIncremental errors too

### DIFF
--- a/src/main/scala/com/dscleaver/sbt/SbtQuickFix.scala
+++ b/src/main/scala/com/dscleaver/sbt/SbtQuickFix.scala
@@ -25,7 +25,7 @@ object SbtQuickFix extends Plugin {
       (key: ScopedKey[_]) => {
         val loggers = currentFunction(key)
         val taskOption = key.scope.task.toOption
-        if(taskOption.map(_.label)  == Some("compile"))
+        if(taskOption.exists(_.label.startsWith("compile")))
           new QuickFixLogger(target / "sbt.quickfix", vimExec, enableServer) +: loggers
         else
           loggers


### PR DESCRIPTION
The newest SBT - at least from version 0.13.8 - using
`compileIncremental` string as the task label for incremental compiling,
not the `compile` string.