### PR TITLE
Neovim support and custom servername

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ If your copy of Vim was compiled with [+clientserver] and you've enabled the `vi
 
 If you don't have [+clientserver] enabled in Vim, or you have disabled the `vim-enable-server` feature of the plugin, then you can use a Vim mapping to load the file.  By default the mapping is `<leader>ff`, but you can change this if you wish.
 
+### Neovim support
+
+If you use Neovim, you have to specify the vim executable as `nvim` in your project or in the global settings: `QuickFixKeys.vimExecutable := "nvim"`
+
+### Default servername/socket
+
+If you use a single instance of **Gvim** you don't need any further configuration to enjoy the integration, since **Gvim** defines `GVIM` as `servername` and this is **sbt-quickfix**'s default value.
+Terminal **Vim** doesn't define a default `servername` so for using the integration you will need to define it explicitly (read the next section)
+
+**Neovim** has replaced Vim's `serverclient` functionality with a more powerful RPC solution. **sbt-quickfix** can connect to **Nvim** using a socket file. **Nvim** doesn't define a default socket, every instance generates a random one instead.
+You can find this socket with `:echo $NVIM_LISTEN_ADDRESS` then you can start `sbt` passing the value as a System Property (read the next section)
+
+### Controlling servername and socket / working with multiple instances
+
+If you want to define the `servername`/`socket` for more predictable behavior or you need it because you work in many projects at a time with multiple **Vim** instances, you can do it easily.
+
+For **Vim** or **Gvim** you have to launch using the `--servername` argument like this: `vim --servername MYPROJECT ...`.
+When you launch `sbt` you have to attach to the specific **Vim** instance using the `sbtquickfix.vim.servername` system property: `sbt -Dsbtquickfix.vim.servername=MYPROJECT ...`
+
+For **Neovim** you can define the socket file as an environment variable before you start **Nvim**: `NVIM_LISTEN_ADDRESS=/tmp/nvim_my_project.sock nvim`.
+When you launch `sbt` you have to attach to the specific **Nvim** instance using the `sbtquickfix.nvim.socket` system property: `sbt -Dsbtquickfix.nvim.socket=/tmp/nvim_my_project.sock  ...` (**sbt-quickfix** uses by default the socket `/tmp/nvim.sock`)
+
 ### Installation Location
 
 By default the plugin will install to `~/.vim/bundle`. This plugin base directory can be added to your global config (e.g. `~/.sbt/0.13/global.sbt`) as follows:

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "com.dscleaver.sbt"
 
 versionWithGit
 
-//version := "0.4.1-LOCAL"
+version := "0.4.2-SNAPSHOT"
 
 git.baseVersion := "0.4.1"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.8

--- a/src/main/scala/com/dscleaver/sbt/SbtQuickFix.scala
+++ b/src/main/scala/com/dscleaver/sbt/SbtQuickFix.scala
@@ -5,7 +5,7 @@ import Keys._
 import sbt.IO._
 import quickfix.{ QuickFixLogger, VimPlugin, QuickFixTestListener }
 
-object SbtQuickFix extends Plugin {
+object SbtQuickFix extends AutoPlugin {
 
   object QuickFixKeys {
     val quickFixDirectory = target in config("quickfix")
@@ -16,6 +16,8 @@ object SbtQuickFix extends Plugin {
   }
 
   import QuickFixKeys._
+
+  override def trigger = allRequirements
 
   override val projectSettings = Seq(
     quickFixDirectory <<= target / "quickfix",

--- a/src/main/scala/com/dscleaver/sbt/SbtQuickFix.scala
+++ b/src/main/scala/com/dscleaver/sbt/SbtQuickFix.scala
@@ -25,7 +25,7 @@ object SbtQuickFix extends Plugin {
       (key: ScopedKey[_]) => {
         val loggers = currentFunction(key)
         val taskOption = key.scope.task.toOption
-        if (taskOption.map(_.label) == Some("compile"))
+        if (taskOption.map(_.label.startsWith("compile")) == Some(true))
           new QuickFixLogger(target / "sbt.quickfix", vimExec, enableServer) +: loggers
         else
           loggers

--- a/src/main/scala/com/dscleaver/sbt/quickfix/QuickFixLogger.scala
+++ b/src/main/scala/com/dscleaver/sbt/quickfix/QuickFixLogger.scala
@@ -3,10 +3,10 @@ package com.dscleaver.sbt.quickfix
 import sbt._
 
 object QuickFixLogger {
-  def append(output: File, prefix: String, message: String): Unit = 
+  def append(output: File, prefix: String, message: String): Unit =
     IO.append(output, "[%s] %s\n".format(prefix, message))
 
-  def append(output: File, prefix: String, file: File, line: Int, message: String): Unit = 
+  def append(output: File, prefix: String, file: File, line: Int, message: String): Unit =
     append(output, prefix, "%s:%d: %s".format(file, line, message))
 }
 
@@ -21,17 +21,18 @@ class QuickFixLogger(val output: File, vimExec: String, enableServer: Boolean) e
     case _ => handleDebugMessage(message)
   }
 
-  def handleDebugMessage(message: String) =
+  def handleDebugMessage(message: String) = {
+    if (message.toLowerCase.contains("initial source changes:")) {
+      IO.delete(output)
+      IO.touch(List(output))
+    }
+
     if (enableServer && message.toLowerCase.contains("compilation failed")) {
       call(vimExec, "<esc>:cfile %s<cr>".format(output.toString))
     }
-
-  def handleInfoMessage(message: String) = {
-    if(message startsWith "Compiling") {
-      IO.delete(output)
-      IO.touch(List(output))
-    } else ()
   }
+
+  def handleInfoMessage(message: String) = ()
 
   def handleErrorMessage(message: String) = append(output, "error", message)
 

--- a/src/main/scala/com/dscleaver/sbt/quickfix/QuickFixLogger.scala
+++ b/src/main/scala/com/dscleaver/sbt/quickfix/QuickFixLogger.scala
@@ -26,12 +26,12 @@ class QuickFixLogger(val output: File, vimExec: String, enableServer: Boolean) e
       IO.delete(output)
       IO.touch(List(output))
       if (enableServer) {
-        call(vimExec, "<esc>:cgetfile %s<cr>".format(output.toString))
+        call(vimExec, "cgetfile %s".format(output.toString))
       }
     }
 
     if (enableServer && message.toLowerCase.contains("compilation failed")) {
-      call(vimExec, "<esc>:cfile %s<cr>".format(output.toString))
+      call(vimExec, "cfile %s".format(output.toString))
     }
   }
 

--- a/src/main/scala/com/dscleaver/sbt/quickfix/QuickFixLogger.scala
+++ b/src/main/scala/com/dscleaver/sbt/quickfix/QuickFixLogger.scala
@@ -25,6 +25,9 @@ class QuickFixLogger(val output: File, vimExec: String, enableServer: Boolean) e
     if (message.toLowerCase.contains("initial source changes:")) {
       IO.delete(output)
       IO.touch(List(output))
+      if (enableServer) {
+        call(vimExec, "<esc>:cgetfile %s<cr>".format(output.toString))
+      }
     }
 
     if (enableServer && message.toLowerCase.contains("compilation failed")) {

--- a/src/main/scala/com/dscleaver/sbt/quickfix/QuickFixTestListener.scala
+++ b/src/main/scala/com/dscleaver/sbt/quickfix/QuickFixTestListener.scala
@@ -22,7 +22,7 @@ class QuickFixTestListener(output: File, srcFiles: => Seq[File], vimExec: String
   def testEvent(event: TestEvent): Unit = {
     writeFailure(event)
     if (enableServer && event.detail.exists(e => e.status == Failure)) {
-      call(vimExec, "<esc>:cfile %s<cr>".format(output.toString))
+      call(vimExec, "cfile %s".format(output.toString))
     }
   }
  

--- a/src/main/scala/com/dscleaver/sbt/quickfix/VimInteraction.scala
+++ b/src/main/scala/com/dscleaver/sbt/quickfix/VimInteraction.scala
@@ -4,8 +4,8 @@ import sbt._
 
 object VimInteraction {
 
-  lazy val vimServerName: String = sys.props.get("sbtquickfix.vim.servername").getOrElse("SBT_QUICKFIX")
-  lazy val nvimSocketFile: String = sys.props.get("sbtquickfix.nvim.socket").getOrElse("/tmp/nvim_sbt_quickfix.sock")
+  lazy val vimServerName: String = sys.props.get("sbtquickfix.vim.servername").getOrElse("GVIM")
+  lazy val nvimSocketFile: String = sys.props.get("sbtquickfix.nvim.socket").getOrElse("/tmp/nvim.sock")
 
   def call(vimExec: String, command: String): Int = vimExec match {
     case "nvim" => Process(List("python", "-c", pyScript(command))).! // TODO revisit when neovim #1750 is resolved

--- a/src/main/scala/com/dscleaver/sbt/quickfix/VimInteraction.scala
+++ b/src/main/scala/com/dscleaver/sbt/quickfix/VimInteraction.scala
@@ -3,7 +3,17 @@ package com.dscleaver.sbt.quickfix
 import sbt._
 
 object VimInteraction {
-  def call(vimExec: String, command: Seq[String]): Int = Process(List(vimExec, "--remote-send") ++ command).!
 
-  def call(vimExec: String, command: String): Int = call(vimExec, List(command))
+  lazy val vimServerName: String = sys.props.get("sbtquickfix.vim.servername").getOrElse("SBT_QUICKFIX")
+  lazy val nvimSocketFile: String = sys.props.get("sbtquickfix.nvim.socket").getOrElse("/tmp/nvim_sbt_quickfix.sock")
+
+  def call(vimExec: String, command: String): Int = vimExec match {
+    case "nvim" => Process(List("python", "-c", pyScript(command))).! // TODO revisit when neovim #1750 is resolved
+    case _      => Process(List(vimExec, "--servername", vimServerName, "--remote-send", s"<esc>:$command<cr>")).!
+  }
+
+  private def pyScript(cmd: String) = 
+     s"""|from neovim import attach
+         |nvim = attach('socket', path='$nvimSocketFile')
+         |nvim.command('$cmd')""".stripMargin
 }


### PR DESCRIPTION
- If Vim executable is `nvim` the quickfix list is reloaded
  using `msgpack-rpc` python client (python and 'neovim' package are
  required).
  Start Neovim with `NVIM_LISTEN_ADDRESS=/tmp/nvim_sbt_quickfix.sock nvim`
- It is now possible to specify a custom `servername` when using `vim`
  or `gvim`
- Added documentation for using the new features
- I also merged many contributions from other forks into master
